### PR TITLE
feat: allow callers to specify GPU proving

### DIFF
--- a/crates/ere-jolt/src/lib.rs
+++ b/crates/ere-jolt/src/lib.rs
@@ -5,7 +5,9 @@ use utils::{
     deserialize_public_input_with_proof, package_name_from_manifest,
     serialize_public_input_with_proof,
 };
-use zkvm_interface::{Compiler, Input, ProgramExecutionReport, ProgramProvingReport, zkVM};
+use zkvm_interface::{
+    Compiler, Input, ProgramExecutionReport, ProgramProvingReport, ProverResourceType, zkVM,
+};
 
 mod jolt_methods;
 mod utils;
@@ -45,7 +47,10 @@ pub struct EreJolt {
 impl zkVM<JOLT_TARGET> for EreJolt {
     type Error = JoltError;
 
-    fn new(program: <JOLT_TARGET as Compiler>::Program) -> Self {
+    fn new(
+        program: <JOLT_TARGET as Compiler>::Program,
+        _resource_type: ProverResourceType,
+    ) -> Self {
         EreJolt { program: program }
     }
 
@@ -105,7 +110,7 @@ impl zkVM<JOLT_TARGET> for EreJolt {
 mod tests {
     use crate::{EreJolt, JOLT_TARGET};
     use std::path::PathBuf;
-    use zkvm_interface::{Compiler, Input, zkVM};
+    use zkvm_interface::{Compiler, Input, ProverResourceType, zkVM};
 
     // TODO: for now, we just get one test file
     // TODO: but this should get the whole directory and compile each test
@@ -135,7 +140,7 @@ mod tests {
         let mut inputs = Input::new();
         inputs.write(&(1 as u32)).unwrap();
 
-        let zkvm = EreJolt::new(program);
+        let zkvm = EreJolt::new(program, ProverResourceType::Cpu);
         let _execution = zkvm.execute(&inputs).unwrap();
     }
     // #[test]

--- a/crates/ere-openvm/src/lib.rs
+++ b/crates/ere-openvm/src/lib.rs
@@ -11,7 +11,9 @@ use openvm_stark_sdk::config::{
     baby_bear_poseidon2::BabyBearPoseidon2Engine,
 };
 use openvm_transpiler::elf::Elf;
-use zkvm_interface::{Compiler, ProgramExecutionReport, ProgramProvingReport, zkVM};
+use zkvm_interface::{
+    Compiler, ProgramExecutionReport, ProgramProvingReport, ProverResourceType, zkVM,
+};
 
 mod error;
 use error::{CompileError, OpenVMError, VerifyError};
@@ -48,7 +50,10 @@ pub struct EreOpenVM {
 impl zkVM<OPENVM_TARGET> for EreOpenVM {
     type Error = OpenVMError;
 
-    fn new(program: <OPENVM_TARGET as Compiler>::Program) -> Self {
+    fn new(
+        program: <OPENVM_TARGET as Compiler>::Program,
+        _resource_type: ProverResourceType,
+    ) -> Self {
         Self { program }
     }
 
@@ -186,7 +191,7 @@ mod tests {
         let test_guest_path = get_compile_test_guest_program_path();
         let elf = OPENVM_TARGET::compile(&test_guest_path).expect("compilation failed");
         let empty_input = zkvm_interface::Input::new();
-        let zkvm = EreOpenVM::new(elf);
+        let zkvm = EreOpenVM::new(elf, ProverResourceType::Cpu);
 
         zkvm.execute(&empty_input).unwrap();
     }
@@ -198,7 +203,7 @@ mod tests {
         let mut input = zkvm_interface::Input::new();
         input.write(&10u64).unwrap();
 
-        let zkvm = EreOpenVM::new(elf);
+        let zkvm = EreOpenVM::new(elf, ProverResourceType::Cpu);
         zkvm.execute(&input).unwrap();
     }
 
@@ -209,7 +214,7 @@ mod tests {
         let mut input = zkvm_interface::Input::new();
         input.write(&10u64).unwrap();
 
-        let zkvm = EreOpenVM::new(elf);
+        let zkvm = EreOpenVM::new(elf, ProverResourceType::Cpu);
         let (proof, _) = zkvm.prove(&input).unwrap();
         zkvm.verify(&proof).expect("proof should verify");
     }

--- a/crates/ere-pico/src/lib.rs
+++ b/crates/ere-pico/src/lib.rs
@@ -1,6 +1,6 @@
 use pico_sdk::client::DefaultProverClient;
 use std::process::Command;
-use zkvm_interface::{Compiler, ProgramProvingReport, zkVM};
+use zkvm_interface::{Compiler, ProgramProvingReport, ProverResourceType, zkVM};
 
 mod error;
 use error::PicoError;
@@ -54,7 +54,10 @@ pub struct ErePico {
 impl zkVM<PICO_TARGET> for ErePico {
     type Error = PicoError;
 
-    fn new(program_bytes: <PICO_TARGET as Compiler>::Program) -> Self {
+    fn new(
+        program_bytes: <PICO_TARGET as Compiler>::Program,
+        _resource_type: ProverResourceType,
+    ) -> Self {
         ErePico {
             program: program_bytes,
         }

--- a/crates/zkvm-interface/src/lib.rs
+++ b/crates/zkvm-interface/src/lib.rs
@@ -15,12 +15,20 @@ pub trait Compiler {
     fn compile(path_to_program: &Path) -> Result<Self::Program, Self::Error>;
 }
 
+/// ResourceType specifies what resource will be used to create the proofs.
+#[derive(Debug, Copy, Clone, Default)]
+pub enum ProverResourceType {
+    #[default]
+    Cpu,
+    Gpu,
+}
+
 #[allow(non_camel_case_types)]
 /// zkVM trait to abstract away the differences between each zkVM
 pub trait zkVM<C: Compiler> {
     type Error: std::error::Error + Send + Sync + 'static;
 
-    fn new(program_bytes: C::Program) -> Self;
+    fn new(program_bytes: C::Program, resource: ProverResourceType) -> Self;
 
     /// Executes the given program with the inputs accumulated in the Input struct.
     /// For RISCV programs, `program_bytes` will be the ELF binary


### PR DESCRIPTION
Currently CPU proving is the default, this allows zkVM implementations to switch between cpu and gpu proving based on the ProverResourceType enum