### PR TITLE
chore: move `new` out of zkvm-interface

### DIFF
--- a/crates/ere-jolt/src/lib.rs
+++ b/crates/ere-jolt/src/lib.rs
@@ -44,15 +44,16 @@ pub struct EreJolt {
     program: <JOLT_TARGET as Compiler>::Program,
 }
 
-impl zkVM<JOLT_TARGET> for EreJolt {
-    type Error = JoltError;
-
+impl EreJolt {
     fn new(
         program: <JOLT_TARGET as Compiler>::Program,
         _resource_type: ProverResourceType,
     ) -> Self {
         EreJolt { program: program }
     }
+}
+impl zkVM for EreJolt {
+    type Error = JoltError;
 
     fn execute(
         &self,

--- a/crates/ere-openvm/src/lib.rs
+++ b/crates/ere-openvm/src/lib.rs
@@ -47,15 +47,16 @@ pub struct EreOpenVM {
     program: <OPENVM_TARGET as Compiler>::Program,
 }
 
-impl zkVM<OPENVM_TARGET> for EreOpenVM {
-    type Error = OpenVMError;
-
+impl EreOpenVM {
     fn new(
         program: <OPENVM_TARGET as Compiler>::Program,
         _resource_type: ProverResourceType,
     ) -> Self {
         Self { program }
     }
+}
+impl zkVM for EreOpenVM {
+    type Error = OpenVMError;
 
     fn execute(
         &self,

--- a/crates/ere-pico/src/lib.rs
+++ b/crates/ere-pico/src/lib.rs
@@ -51,10 +51,8 @@ pub struct ErePico {
     program: <PICO_TARGET as Compiler>::Program,
 }
 
-impl zkVM<PICO_TARGET> for ErePico {
-    type Error = PicoError;
-
-    fn new(
+impl ErePico {
+    pub fn new(
         program_bytes: <PICO_TARGET as Compiler>::Program,
         _resource_type: ProverResourceType,
     ) -> Self {
@@ -62,6 +60,9 @@ impl zkVM<PICO_TARGET> for ErePico {
             program: program_bytes,
         }
     }
+}
+impl zkVM for ErePico {
+    type Error = PicoError;
 
     fn execute(
         &self,

--- a/crates/ere-sp1/src/lib.rs
+++ b/crates/ere-sp1/src/lib.rs
@@ -92,10 +92,8 @@ impl Compiler for RV32_IM_SUCCINCT_ZKVM_ELF {
     }
 }
 
-impl zkVM<RV32_IM_SUCCINCT_ZKVM_ELF> for EreSP1 {
-    type Error = SP1Error;
-
-    fn new(
+impl EreSP1 {
+    pub fn new(
         program: <RV32_IM_SUCCINCT_ZKVM_ELF as Compiler>::Program,
         resource: ProverResourceType,
     ) -> Self {
@@ -112,6 +110,10 @@ impl zkVM<RV32_IM_SUCCINCT_ZKVM_ELF> for EreSP1 {
             vk,
         }
     }
+}
+
+impl zkVM for EreSP1 {
+    type Error = SP1Error;
 
     fn execute(
         &self,

--- a/crates/zkvm-interface/src/lib.rs
+++ b/crates/zkvm-interface/src/lib.rs
@@ -25,10 +25,8 @@ pub enum ProverResourceType {
 
 #[allow(non_camel_case_types)]
 /// zkVM trait to abstract away the differences between each zkVM
-pub trait zkVM<C: Compiler> {
+pub trait zkVM {
     type Error: std::error::Error + Send + Sync + 'static;
-
-    fn new(program_bytes: C::Program, resource: ProverResourceType) -> Self;
 
     /// Executes the given program with the inputs accumulated in the Input struct.
     /// For RISCV programs, `program_bytes` will be the ELF binary


### PR DESCRIPTION
Main benefit is that the `zkVM` trait is no longer parametrized by Compiler, so we can have a heterogenous list of `dyn zkVM` that have different programs and also `zkVM` is now object safe