### PR TITLE
chore: concerete zkVM Error

### DIFF
--- a/crates/ere-jolt/src/error.rs
+++ b/crates/ere-jolt/src/error.rs
@@ -1,0 +1,13 @@
+use zkvm_interface::zkVMError;
+
+impl From<JoltError> for zkVMError {
+    fn from(value: JoltError) -> Self {
+        zkVMError::Other(Box::new(value))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum JoltError {
+    #[error("Proof verification failed")]
+    ProofVerificationFailed,
+}

--- a/crates/ere-jolt/src/lib.rs
+++ b/crates/ere-jolt/src/lib.rs
@@ -1,3 +1,4 @@
+use error::JoltError;
 use jolt_core::host::Program;
 use jolt_methods::{preprocess_prover, preprocess_verifier, prove_generic, verify_generic};
 use jolt_sdk::host::DEFAULT_TARGET_DIR;
@@ -7,19 +8,15 @@ use utils::{
 };
 use zkvm_interface::{
     Compiler, Input, ProgramExecutionReport, ProgramProvingReport, ProverResourceType, zkVM,
+    zkVMError,
 };
 
+mod error;
 mod jolt_methods;
 mod utils;
 
 #[allow(non_camel_case_types)]
 pub struct JOLT_TARGET;
-
-#[derive(Debug, thiserror::Error)]
-pub enum JoltError {
-    #[error("Proof verification failed")]
-    ProofVerificationFailed,
-}
 
 impl Compiler for JOLT_TARGET {
     type Error = JoltError;
@@ -53,12 +50,10 @@ impl EreJolt {
     }
 }
 impl zkVM for EreJolt {
-    type Error = JoltError;
-
     fn execute(
         &self,
         inputs: &zkvm_interface::Input,
-    ) -> Result<zkvm_interface::ProgramExecutionReport, Self::Error> {
+    ) -> Result<zkvm_interface::ProgramExecutionReport, zkVMError> {
         // TODO: check ProgramSummary
         let summary = self
             .program
@@ -72,7 +67,7 @@ impl zkVM for EreJolt {
     fn prove(
         &self,
         inputs: &zkvm_interface::Input,
-    ) -> Result<(Vec<u8>, zkvm_interface::ProgramProvingReport), Self::Error> {
+    ) -> Result<(Vec<u8>, zkvm_interface::ProgramProvingReport), zkVMError> {
         // TODO: make this stateful and do in setup since its expensive and should be done once per program;
         let preprocessed_key = preprocess_prover(&self.program);
 
@@ -86,7 +81,7 @@ impl zkVM for EreJolt {
         Ok((proof_with_public_inputs, ProgramProvingReport::new(elapsed)))
     }
 
-    fn verify(&self, proof_with_public_inputs: &[u8]) -> Result<(), Self::Error> {
+    fn verify(&self, proof_with_public_inputs: &[u8]) -> Result<(), zkVMError> {
         let preprocessed_verifier = preprocess_verifier(&self.program);
         let (public_inputs, proof) =
             deserialize_public_input_with_proof(proof_with_public_inputs).unwrap();
@@ -102,7 +97,7 @@ impl zkVM for EreJolt {
         if valid {
             Ok(())
         } else {
-            Err(JoltError::ProofVerificationFailed)
+            Err(JoltError::ProofVerificationFailed).map_err(zkVMError::from)
         }
     }
 }

--- a/crates/ere-openvm/src/error.rs
+++ b/crates/ere-openvm/src/error.rs
@@ -1,4 +1,11 @@
 use thiserror::Error;
+use zkvm_interface::zkVMError;
+
+impl From<OpenVMError> for zkVMError {
+    fn from(value: OpenVMError) -> Self {
+        zkVMError::Other(Box::new(value))
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum OpenVMError {

--- a/crates/ere-pico/src/error.rs
+++ b/crates/ere-pico/src/error.rs
@@ -1,5 +1,12 @@
 use std::{io, path::PathBuf, process::ExitStatus};
 use thiserror::Error;
+use zkvm_interface::zkVMError;
+
+impl From<PicoError> for zkVMError {
+    fn from(value: PicoError) -> Self {
+        zkVMError::Other(Box::new(value))
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum PicoError {

--- a/crates/ere-pico/src/lib.rs
+++ b/crates/ere-pico/src/lib.rs
@@ -1,6 +1,6 @@
 use pico_sdk::client::DefaultProverClient;
 use std::process::Command;
-use zkvm_interface::{Compiler, ProgramProvingReport, ProverResourceType, zkVM};
+use zkvm_interface::{Compiler, ProgramProvingReport, ProverResourceType, zkVM, zkVMError};
 
 mod error;
 use error::PicoError;
@@ -62,19 +62,17 @@ impl ErePico {
     }
 }
 impl zkVM for ErePico {
-    type Error = PicoError;
-
     fn execute(
         &self,
         _inputs: &zkvm_interface::Input,
-    ) -> Result<zkvm_interface::ProgramExecutionReport, Self::Error> {
+    ) -> Result<zkvm_interface::ProgramExecutionReport, zkVMError> {
         todo!("pico currently does not have an execute method exposed via the SDK")
     }
 
     fn prove(
         &self,
         inputs: &zkvm_interface::Input,
-    ) -> Result<(Vec<u8>, zkvm_interface::ProgramProvingReport), Self::Error> {
+    ) -> Result<(Vec<u8>, zkvm_interface::ProgramProvingReport), zkVMError> {
         let client = DefaultProverClient::new(&self.program);
 
         let mut stdin = client.new_stdin_builder();
@@ -103,7 +101,7 @@ impl zkVM for ErePico {
         Ok((proof_serialized, ProgramProvingReport::new(elapsed)))
     }
 
-    fn verify(&self, _proof: &[u8]) -> Result<(), Self::Error> {
+    fn verify(&self, _proof: &[u8]) -> Result<(), zkVMError> {
         let client = DefaultProverClient::new(&self.program);
 
         let _vk = client.riscv_vk();

--- a/crates/ere-sp1/src/error.rs
+++ b/crates/ere-sp1/src/error.rs
@@ -1,6 +1,13 @@
 use std::{path::PathBuf, process::ExitStatus};
 
 use thiserror::Error;
+use zkvm_interface::zkVMError;
+
+impl From<SP1Error> for zkVMError {
+    fn from(value: SP1Error) -> Self {
+        zkVMError::Other(Box::new(value))
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum SP1Error {

--- a/crates/zkvm-interface/src/lib.rs
+++ b/crates/zkvm-interface/src/lib.rs
@@ -1,6 +1,7 @@
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::{path::Path, time::Duration};
+use thiserror::Error;
 
 mod input;
 pub use input::Input;
@@ -23,25 +24,37 @@ pub enum ProverResourceType {
     Gpu,
 }
 
+/// An error that can occur during prove, execute or verification
+/// of a zkVM.
+///
+/// Note: We use a concrete error type here, so that downstream crates
+/// can do patterns such as Vec<dyn zkVM>
+#[allow(non_camel_case_types)]
+#[derive(Debug, Error)]
+pub enum zkVMError {
+    // TODO: We can add more variants as time goes by.
+    // TODO: for now, we use this catch-all as a way to prototype faster
+    #[error(transparent)]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
 #[allow(non_camel_case_types)]
 #[auto_impl::auto_impl(&, Arc, Box)]
 /// zkVM trait to abstract away the differences between each zkVM
 pub trait zkVM {
-    type Error: std::error::Error + Send + Sync + 'static;
-
     /// Executes the given program with the inputs accumulated in the Input struct.
     /// For RISCV programs, `program_bytes` will be the ELF binary
-    fn execute(&self, inputs: &Input) -> Result<ProgramExecutionReport, Self::Error>;
+    fn execute(&self, inputs: &Input) -> Result<ProgramExecutionReport, zkVMError>;
 
     /// Creates a proof for a given program
-    fn prove(&self, inputs: &Input) -> Result<(Vec<u8>, ProgramProvingReport), Self::Error>;
+    fn prove(&self, inputs: &Input) -> Result<(Vec<u8>, ProgramProvingReport), zkVMError>;
 
     /// Verifies a proof for the given program
     /// TODO: Pass public inputs too and check that they match if they come with the
     /// TODO: proof, or append them if they do not.
     /// TODO: We can also just have this return the public inputs, but then the user needs
     /// TODO: ensure they check it for correct #[must_use]
-    fn verify(&self, proof: &[u8]) -> Result<(), Self::Error>;
+    fn verify(&self, proof: &[u8]) -> Result<(), zkVMError>;
 }
 
 /// ProgramExecutionReport produces information about a particular program


### PR DESCRIPTION
Rationale is the same for removing Compiler trait from the zkVM trait -- so that we can do something like `Vec<dyn zkVM>`

It may be possible that we bring this back, but for now this seems to be the best way to expose multiple zkVMs for the end users