### PR TITLE
zkvm-interface: add execution duration

### DIFF
--- a/crates/ere-pico/src/lib.rs
+++ b/crates/ere-pico/src/lib.rs
@@ -1,5 +1,5 @@
 use pico_sdk::client::DefaultProverClient;
-use std::process::Command;
+use std::{process::Command, time::Instant};
 use zkvm_interface::{
     Compiler, Input, InputItem, ProgramExecutionReport, ProgramProvingReport, ProverResourceType,
     zkVM, zkVMError,
@@ -75,9 +75,15 @@ impl zkVM for ErePico {
                 InputItem::Bytes(items) => stdin.write_slice(items),
             }
         }
+
+        let start = Instant::now();
         let num_cycles = client.emulate(stdin);
 
-        Ok(ProgramExecutionReport::new(num_cycles))
+        Ok(ProgramExecutionReport {
+            total_num_cycles: num_cycles,
+            execution_duration: start.elapsed(),
+            ..Default::default()
+        })
     }
 
     fn prove(

--- a/crates/ere-risczero/src/lib.rs
+++ b/crates/ere-risczero/src/lib.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use compile::compile_risczero_program;
 use risc0_zkvm::{ExecutorEnv, Receipt, default_executor, default_prover};
 use zkvm_interface::{
@@ -69,12 +71,14 @@ impl zkVM for EreRisc0 {
         }
         let env = env.build().map_err(|err| zkVMError::Other(err.into()))?;
 
+        let start = Instant::now();
         let session_info = executor
             .execute(env, &self.program.elf)
             .map_err(|err| zkVMError::Other(err.into()))?;
         Ok(ProgramExecutionReport {
             total_num_cycles: session_info.cycles() as u64,
-            region_cycles: Default::default(),
+            execution_duration: start.elapsed(),
+            ..Default::default()
         })
     }
 

--- a/crates/ere-zisk/src/lib.rs
+++ b/crates/ere-zisk/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
     process::{Command, Stdio},
-    time,
+    time::{self, Instant},
 };
 use tempfile::tempdir;
 use zkvm_interface::{
@@ -88,6 +88,7 @@ impl zkVM for EreZisk {
             .into());
         }
 
+        let start = Instant::now();
         let total_num_cycles = String::from_utf8_lossy(&output.stdout)
             .split_once("total steps = ")
             .and_then(|(_, stats)| {
@@ -98,7 +99,11 @@ impl zkVM for EreZisk {
             })
             .ok_or(ZiskError::Execute(ExecuteError::TotalStepsNotFound))?;
 
-        Ok(ProgramExecutionReport::new(total_num_cycles))
+        Ok(ProgramExecutionReport {
+            total_num_cycles,
+            execution_duration: start.elapsed(),
+            ..Default::default()
+        })
     }
 
     fn prove(&self, input: &Input) -> Result<(Vec<u8>, ProgramProvingReport), zkVMError> {

--- a/crates/zkvm-interface/src/reports.rs
+++ b/crates/zkvm-interface/src/reports.rs
@@ -10,13 +10,15 @@ pub struct ProgramExecutionReport {
     pub total_num_cycles: u64,
     /// Region-specific cycles, mapping region names (e.g., "setup", "compute") to their cycle counts.
     pub region_cycles: IndexMap<String, u64>,
+    /// Execution duration.
+    pub execution_duration: Duration,
 }
 
 impl ProgramExecutionReport {
     pub fn new(total_num_cycles: u64) -> Self {
         ProgramExecutionReport {
             total_num_cycles,
-            region_cycles: Default::default(),
+            ..Default::default()
         }
     }
     pub fn insert_region(&mut self, region_name: String, num_cycles: u64) {


### PR DESCRIPTION
This PR adds a new field `execution_duration` to `ProgramExecutionReport`. This allows for later analytics around `cycles/second` or simply raw-zkVM raw execution performance.